### PR TITLE
[easyTag] respect tag sort name

### DIFF
--- a/plugins/QuickEdit/quickedit_classes.js
+++ b/plugins/QuickEdit/quickedit_classes.js
@@ -5,10 +5,11 @@ const GroupType = {
 }
 
 class TagConfiguration{
-    constructor(id = -1, name = "", stashName = "", group = ""){
+    constructor(id = -1, name = "", stashName = "", stashSortName="", group = ""){
         this.stashId = id
         this.name = name
         this.stashName = stashName
+        this.stashSortName = stashSortName
         this.group = group
     }
 
@@ -17,6 +18,7 @@ class TagConfiguration{
             savedObject.stashId,
             savedObject.name,
             savedObject.stashName,
+            savedObject.stashSortName,
             savedObject.group
         )
     }
@@ -26,12 +28,22 @@ class TagConfiguration{
             Number(stashTagData.id),
             "",
             stashTagData.name,
+            stashTagData.sort_name,
             ""
         )
     }
 
+    updateFromStashTag(stashTagData)  {
+        this.stashName =  stashTagData.name;
+        this.stashSortName = stashTagData.sort_name;
+    }
+
     getDisplayName(){
         return this.name != "" ? this.name : this.stashName
+    }
+
+    getSortName(){
+        return this.name != "" ? this.name : (this.stashSortName != '' ? this.stashSortName : this.stashName)
     }
 }
 

--- a/plugins/QuickEdit/quickedit_classes.js
+++ b/plugins/QuickEdit/quickedit_classes.js
@@ -38,12 +38,12 @@ class TagConfiguration{
         this.stashSortName = stashTagData.sort_name;
     }
 
-    getDisplayName(){
+    getDisplayName() {
         return this.name != "" ? this.name : this.stashName
     }
 
-    getSortName(){
-        return this.name != "" ? this.name : (this.stashSortName != '' ? this.stashSortName : this.stashName)
+    getSortName() {
+        return (this.stashSortName ? this.stashSortName : '') + this.getDisplayName();
     }
 }
 

--- a/plugins/QuickEdit/quickedit_config.js
+++ b/plugins/QuickEdit/quickedit_config.js
@@ -78,8 +78,8 @@ class ButtonsConfig{
 
     orderTags(){
         let orderedTags = this.tags.sort((tagA, tagB) => {
-            let nameA = tagA.getDisplayName()
-            let nameB = tagB.getDisplayName()
+            let nameA = tagA.getSortName()
+            let nameB = tagB.getSortName()
             return nameA.localeCompare(nameB)
         })
         this.tags = orderedTags
@@ -88,6 +88,7 @@ class ButtonsConfig{
     getOrCreateTag(stashTagData){
         let tag = this.getTag(stashTagData.id)
         if(tag){
+            tag.updateFromStashTag(stashTagData)
             return tag
         }
         tag = TagConfiguration.fromStashTag(stashTagData)
@@ -386,9 +387,13 @@ class ButtonsConfigUI{
         listContainer.innerHTML = ""
 
         this.stashQL.getAllTags().then((tags) => {
-            this.allStashTags = tags.data.allTags
+            this.allStashTags = tags.data.findTags.tags
             for (const tag of this.allStashTags) {
                 let tagC = this.buttonsConfig.getTag(tag.id)
+                // already exists -> update stash data (name, sort name)
+                if (tagC) {
+                    tagC.updateFromStashTag(tag);
+                }
 
                 const tagElement = document.createElement("div")
                 tagElement.setAttribute("class", "tag-list-row row")

--- a/plugins/QuickEdit/quickedit_stashQL.js
+++ b/plugins/QuickEdit/quickedit_stashQL.js
@@ -192,19 +192,29 @@ class StashGraphQL{
     }
 
     async getAllTags(){
-        const query = `query AllTagsForFilter {
-            allTags {
-              id
-              name
-              aliases
-              __typename
+        const query = `query FindTags($filter: FindFilterType, $tag_filter: TagFilterType) {
+            findTags(filter: $filter, tag_filter: $tag_filter) {
+                count
+                tags {
+                    id
+                    name
+                    sort_name
+                    aliases
+                    __typename
+                }
+                __typename
             }
-          }
+        }
         `
         const queryBody = {
-            operationName : "AllTagsForFilter",
+            operationName : "FindTags",
             query : query,
             variables : {
+                "filter": {
+                    "sort": "name",
+                    "page": 1,
+                    "per_page": 99999
+                }
             }
         }
 


### PR DESCRIPTION
Previously, tag order enforced through sort names got ignored, now it should be respected in both the all tag list in the config view, and within configured groups in the Quick Edit view (unless a display name is set).

This change also has the side effect of updating tag stash name and sort name on initialization, so a saved config should be kept in sync with server-side changes better