### PR TITLE
[easyTag] fix clear config and load config

### DIFF
--- a/plugins/QuickEdit/quickedit_config.js
+++ b/plugins/QuickEdit/quickedit_config.js
@@ -156,7 +156,7 @@ class ButtonsConfig{
         setTimeout(function() { URL.revokeObjectURL(a.href); }, 1500);
     }
 
-    loadConfigFromFile(fileContent){
+    async loadConfigFromFile(fileContent){
         let loadedConfig = JSON.parse(fileContent)
 
         if("groups" in loadedConfig && "tags" in loadedConfig){
@@ -164,14 +164,14 @@ class ButtonsConfig{
             Object.keys(this.groups).forEach((key) => this.groups[key] = GroupConfiguration.fromSavedData(this.groups[key], key))
             this.tags = loadedConfig.tags
             Object.keys(this.tags).forEach((key) => this.tags[key] = TagConfiguration.fromSavedData(this.tags[key]))
-            this.saveConfig()
+            await this.saveConfig()
         }
     }
 
-    clearConfig(){
+    async clearConfig(){
         this.groups = {}
         this.tags = []
-        this.saveConfig()
+        await this.saveConfig()
     }
 }
 
@@ -225,8 +225,9 @@ class ButtonsConfigUI{
         this.BTNCFG_CONTAINER.querySelector("#configModalClearConfig").addEventListener("click", (e) => {
             e.preventDefault()
             if(confirm("This will delete your QuickEdit config permanently. Are you sure ?")){
-                this.buttonsConfig.clearConfig()
-                window.location.reload()
+                this.buttonsConfig.clearConfig().then(() => {
+                    window.location.reload();
+                });
             }
         })
     }

--- a/plugins/QuickEdit/quickedit_config.js
+++ b/plugins/QuickEdit/quickedit_config.js
@@ -210,8 +210,9 @@ class ButtonsConfigUI{
                 var reader = new FileReader()
                 reader.readAsText(file,'UTF-8')
                 reader.onload = readerEvent => {
-                    this.buttonsConfig.loadConfigFromFile(readerEvent.target.result)
-                    window.location.reload()
+                    this.buttonsConfig.loadConfigFromFile(readerEvent.target.result).then(() => {
+                        window.location.reload();
+                    });
                 }
             }
             input.click()


### PR DESCRIPTION
These were probably broken since the transition from LocalStorage to server-side storage. The reload triggered immediately, not waiting for saveConfig to complete, cancelling the request and not actually saving.